### PR TITLE
Support anonymous saving and refector

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ If you got error on tapping the formula. try `brew untap giginet/toybox` before.
 $ toybox create UIKitDemo
 # Create a new Playground which is not saved
 $ toybox create
+# Create a new auto generated named Playground which is saved like 20190404082446.playground
+$ toybox create -s
 # Create 'SpriteKit.playground' for macOS
 $ toybox create SpriteKitDemo --platform macos
 # Overwrite existing playground 'UIKitDemo'

--- a/Sources/ToyboxKit/Handler.swift
+++ b/Sources/ToyboxKit/Handler.swift
@@ -67,13 +67,31 @@ public struct PlaygroundHandler<Workspace: WorkspaceType, Opener: PlaygroundOpen
         return .success(filteredPlaygrounds.map { String(describing: $0) })
     }
 
-    public func create(_ name: String?, for platform: Platform, force: Bool = false, temporary: Bool = false) -> Result<Playground, ToyboxError> {
-        let baseName: String = name ?? generateDefaultFileName()
-        let targetPath = fullPath(from: baseName, temporary: temporary)
+    public enum NewPlaygroundKind {
+        case named(String)
+        case anonymous
+        case temporary
+    }
+
+    public func create(_ kind: NewPlaygroundKind, for platform: Platform, force: Bool = false) -> Result<Playground, ToyboxError> {
+        let baseName: String
+        let shouldSaveToTemporary: Bool
+        switch kind {
+        case .named(let name):
+            baseName = name
+            shouldSaveToTemporary = false
+        case .anonymous:
+            baseName = generateDefaultFileName()
+            shouldSaveToTemporary = false
+        case .temporary:
+            baseName = generateDefaultFileName()
+            shouldSaveToTemporary = true
+        }
+        let targetPath = fullPath(from: baseName, temporary: shouldSaveToTemporary)
 
         if isExist(at: targetPath) {
             do {
-                if force || temporary {
+                if force || shouldSaveToTemporary {
                     let manager = FileManager()
                     try manager.removeItem(at: targetPath)
                 } else {

--- a/Sources/ToyboxKit/Handler.swift
+++ b/Sources/ToyboxKit/Handler.swift
@@ -113,6 +113,7 @@ public struct PlaygroundHandler<Workspace: WorkspaceType, Opener: PlaygroundOpen
         return .success(playground)
     }
 
+    @discardableResult
     public func open(_ playground: Playground, with xcodePath: URL? = nil) -> Result<(), ToyboxError> {
         let path = playground.path
         if isExist(at: path) {
@@ -122,7 +123,7 @@ public struct PlaygroundHandler<Workspace: WorkspaceType, Opener: PlaygroundOpen
         }
         return .success(())
     }
-    
+
     public func playground(for name: String) -> Playground? {
         return playgrounds.first { $0.name == name }
     }

--- a/Sources/toybox/Commands/Create.swift
+++ b/Sources/toybox/Commands/Create.swift
@@ -13,8 +13,8 @@ struct CreateOptions: OptionsProtocol {
     let enableStandardInput: Bool
     let xcodePath: URL?
 
-    static func create(_ platform: Platform) -> (String?) -> ([String]) -> (Bool) -> (Bool) -> (Bool) -> (Bool) -> CreateOptions {
-        return { xcodePathString in { fileNames in { force in { noOpen in { store in { standardInput in
+    static func create(_ platform: Platform) -> (String?) -> (Bool) -> ([String]) -> (Bool) -> (Bool) -> (Bool) -> CreateOptions {
+        return { xcodePathString in { store in { fileNames in { force in { noOpen in { standardInput in
             let xcodePath: URL?
             if let xcodePathString = xcodePathString {
                 xcodePath = URL(fileURLWithPath: xcodePathString)
@@ -36,9 +36,9 @@ struct CreateOptions: OptionsProtocol {
         return create
             <*> m <| Option(key: "platform", defaultValue: Platform.iOS, usage: "Target platform (ios/macos/tvos)")
             <*> m <| Option<String?>(key: "xcode-path", defaultValue: nil, usage: "Xcode path to open with")
+            <*> m <| Switch(flag: "s", key: "store", usage: "Whether to save to workspace as anonymous playground")
             <*> m <| Argument(defaultValue: [], usage: "Playground file name to create")
             <*> m <| Switch(flag: "f", key: "force", usage: "Whether to overwrite existing playground")
-            <*> m <| Switch(flag: "s", key: "store", usage: "Whether to save to workspace as anonymous playground")
             <*> m <| Switch(key: "no-open", usage: "Whether to open new playground")
             <*> m <| Switch(key: "input", usage: "Whether to enable standard input")
     }
@@ -81,9 +81,8 @@ struct CreateCommand: CommandProtocol {
             }
 
             if !options.noOpen {
-                _ = handler.open(playground.name,
-                                 with: options.xcodePath,
-                                 temporary: shouldStore)
+                _ = handler.open(playground,
+                                 with: options.xcodePath)
             }
             return .success(())
         case let .failure(error):

--- a/Sources/toybox/Commands/Create.swift
+++ b/Sources/toybox/Commands/Create.swift
@@ -9,12 +9,12 @@ struct CreateOptions: OptionsProtocol {
     let platform: Platform
     let force: Bool
     let noOpen: Bool
-    let store: Bool
+    let save: Bool
     let enableStandardInput: Bool
     let xcodePath: URL?
 
     static func create(_ platform: Platform) -> (String?) -> (Bool) -> ([String]) -> (Bool) -> (Bool) -> (Bool) -> CreateOptions {
-        return { xcodePathString in { store in { fileNames in { force in { noOpen in { standardInput in
+        return { xcodePathString in { save in { fileNames in { force in { noOpen in { standardInput in
             let xcodePath: URL?
             if let xcodePathString = xcodePathString {
                 xcodePath = URL(fileURLWithPath: xcodePathString)
@@ -25,7 +25,7 @@ struct CreateOptions: OptionsProtocol {
                              platform: platform,
                              force: force,
                              noOpen: noOpen,
-                             store: store,
+                             save: save,
                              enableStandardInput: standardInput,
                              xcodePath: xcodePath)
             } } } } }
@@ -36,7 +36,7 @@ struct CreateOptions: OptionsProtocol {
         return create
             <*> m <| Option(key: "platform", defaultValue: Platform.iOS, usage: "Target platform (ios/macos/tvos)")
             <*> m <| Option<String?>(key: "xcode-path", defaultValue: nil, usage: "Xcode path to open with")
-            <*> m <| Switch(flag: "s", key: "store", usage: "Whether to save to workspace as anonymous playground")
+            <*> m <| Switch(flag: "s", key: "save", usage: "Whether to save to workspace as anonymous playground")
             <*> m <| Argument(defaultValue: [], usage: "Playground file name to create")
             <*> m <| Switch(flag: "f", key: "force", usage: "Whether to overwrite existing playground")
             <*> m <| Switch(key: "no-open", usage: "Whether to open new playground")
@@ -57,9 +57,8 @@ struct CreateCommand: CommandProtocol {
             return .failure(error)
         }
 
-        let shouldStore = options.store || (options.fileName == nil)
         let kind: ToyboxPlaygroundHandler.NewPlaygroundKind
-        switch (options.store, options.fileName) {
+        switch (options.save, options.fileName) {
         case (false, .some(let fileName)):
             kind = .named(fileName)
         case (true, .some(let fileName)):

--- a/Sources/toybox/Commands/Open.swift
+++ b/Sources/toybox/Commands/Open.swift
@@ -37,7 +37,10 @@ struct OpenCommand: CommandProtocol {
     func run(_ options: Options) -> Result<(), ToyboxError> {
         let handler = ToyboxPlaygroundHandler()
         let fileName = options.fileName
-        if case let .failure(error) = handler.open(fileName, with: options.xcodePath) {
+        guard let playground = handler.playground(for: fileName) else {
+            return .failure(ToyboxError.openError("\(fileName) is not exist"))
+        }
+        if case let .failure(error) = handler.open(playground, with: options.xcodePath) {
             return .failure(error)
         }
         return .success(())

--- a/Tests/ToyboxKitTests/HandlerTests.swift
+++ b/Tests/ToyboxKitTests/HandlerTests.swift
@@ -78,13 +78,19 @@ class HandlerTests: XCTestCase {
         XCTAssertTrue(manager.fileExists(atPath: playgroundURL(for: "hello").path))
     }
 
+    func name(from date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyyMMddHHmmss"
+        return formatter.string(from: date)
+    }
+
     func testCreateAnonymous() {
         XCTAssertFalse(manager.fileExists(atPath: playgroundURL(for: "hello").path))
         let result = handler.create(.anonymous, for: .iOS)
         switch result {
         case .success(let playground):
             XCTAssertTrue(manager.fileExists(atPath: playgroundURL(for: playground.name).path))
-            XCTAssertEqual(playground.name, "20190404090205")
+            XCTAssertEqual(playground.name, name(from: TestingDateProvider.date))
         case .failure:
             XCTFail("handler.list should be failed")
         }

--- a/Tests/ToyboxKitTests/HandlerTests.swift
+++ b/Tests/ToyboxKitTests/HandlerTests.swift
@@ -18,7 +18,7 @@ struct AssertOpener: PlaygroundOpener {
 }
 
 struct TestingDateProvider: DateProvider {
-    static var date: Date = .init(timeIntervalSinceReferenceDate: 0)
+    static var date: Date = .init(timeIntervalSince1970: 1554336125.712433)
 }
 
 typealias TestingPlaygroundHandler = PlaygroundHandler<TestingStorage, TestingDateProvider, AssertOpener>
@@ -84,7 +84,7 @@ class HandlerTests: XCTestCase {
         switch result {
         case .success(let playground):
             XCTAssertTrue(manager.fileExists(atPath: playgroundURL(for: playground.name).path))
-            XCTAssertEqual(playground.name, "20010101090000")
+            XCTAssertEqual(playground.name, "20190404090205")
         case .failure:
             XCTFail("handler.list should be failed")
         }

--- a/Tests/ToyboxKitTests/HandlerTests.swift
+++ b/Tests/ToyboxKitTests/HandlerTests.swift
@@ -98,7 +98,7 @@ class HandlerTests: XCTestCase {
 
     func testCreateWithTemporaryOption() {
         _ = handler.create(.temporary, for: .iOS)
-        XCTAssertTrue(manager.fileExists(atPath: temporaryPlaygroundURL(for: "hello").path))
+        XCTAssertTrue(manager.fileExists(atPath: temporaryPlaygroundURL(for: name(from: TestingDateProvider.date)).path))
         XCTAssertFalse(manager.fileExists(atPath: playgroundURL(for: "hello").path))
     }
 

--- a/Tests/ToyboxKitTests/HandlerTests.swift
+++ b/Tests/ToyboxKitTests/HandlerTests.swift
@@ -46,8 +46,8 @@ class HandlerTests: XCTestCase {
         }
         XCTAssertTrue(list0.isEmpty)
 
-        _ = handler.create("ios", for: .iOS)
-        _ = handler.create("mac", for: .macOS)
+        _ = handler.create(.named("ios"), for: .iOS)
+        _ = handler.create(.named("mac"), for: .macOS)
 
         guard case let .success(list1) = handler.list() else {
             XCTFail("handler.list should be success")
@@ -64,7 +64,7 @@ class HandlerTests: XCTestCase {
 
     func testCreate() {
         XCTAssertFalse(manager.fileExists(atPath: playgroundURL(for: "hello").path))
-        let result = handler.create("hello", for: .iOS)
+        let result = handler.create(.named("hello"), for: .iOS)
         if case .failure(_) = result {
             XCTFail("handler.list should be failed")
         }
@@ -72,14 +72,14 @@ class HandlerTests: XCTestCase {
     }
 
     func testCreateWithTemporaryOption() {
-        _ = handler.create("hello", for: .iOS, temporary: true)
+        _ = handler.create(.temporary, for: .iOS)
         XCTAssertTrue(manager.fileExists(atPath: temporaryPlaygroundURL(for: "hello").path))
         XCTAssertFalse(manager.fileExists(atPath: playgroundURL(for: "hello").path))
     }
 
     func testListDoesNotShowTemporaryFile() {
-        _ = handler.create("foo", for: .iOS)
-        _ = handler.create("bar", for: .iOS, temporary: true)
+        _ = handler.create(.named("foo"), for: .iOS)
+        _ = handler.create(.temporary, for: .iOS)
 
         guard case let .success(list1) = handler.list() else {
             XCTFail("handler.list should be success")
@@ -97,8 +97,13 @@ class HandlerTests: XCTestCase {
             }
         }
         let handler = PlaygroundHandler<TestingStorage, AssertOpener>()
-        _ = handler.create("foobar", for: .iOS)
-        _ = handler.open("foobar")
+        let result = handler.create(.named("foobar"), for: .iOS)
+        switch result {
+        case .success(let playground):
+            _ = handler.open(playground)
+        case .failure:
+            XCTFail("Could not create playground")
+        }
         XCTAssertTrue(AssertOpener.opened)
     }
 
@@ -111,9 +116,14 @@ class HandlerTests: XCTestCase {
             }
         }
         let handler = PlaygroundHandler<TestingStorage, AssertOpener>()
-        _ = handler.create("foobar", for: .iOS, temporary: true)
-        _ = handler.open("foobar", temporary: true)
-        XCTAssertTrue(AssertOpener.opened)
+        let result = handler.create(.temporary, for: .iOS)
+        switch result {
+        case .success(let playground):
+            handler.open(playground)
+            XCTAssertTrue(AssertOpener.opened)
+        case .failure:
+            XCTFail("Playground is not created")
+        }
     }
 
     override func tearDown() {


### PR DESCRIPTION
Support `-s` option.

You can save an anonymous playground like this.
```console
$ toybox create -s
Create 20190404082446.playground for iOS
```

@omochi どうぞご利用ください